### PR TITLE
Stop counting "attempted"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,8 +49,6 @@ fn check_server(addr: &str, name: &str, timeout: Duration, interval: u8, statsd_
     loop {
         debug!("Checking availability of the SMTP server {} [{}]", name, addr);
         let mut pipe = statsd_client.pipeline();
-        // Increase attempted counter
-        pipe.incr(format!("smtp.{}.attempted", name).as_str());
         /* Measure latency time */
         statsd_client.time(format!("smtp.{}", name).as_str(), || {
             let mut success: bool = false;


### PR DESCRIPTION
This sound useful, but under this location is only creating problems on
the visualization side, where they always need to be explicitly
excluded.
